### PR TITLE
fix some stuff

### DIFF
--- a/recipe/intltool-perl-5.22.patch
+++ b/recipe/intltool-perl-5.22.patch
@@ -1,0 +1,43 @@
+--- intltool-update.in	2015-03-09 02:39:54.000000000 +0100
++++ intltool-update.in	2015-09-01 11:43:40.595517191 +0200
+@@ -1062,7 +1062,7 @@
+ 	}
+     }
+ 
+-    if ($str =~ /^(.*)\${?([A-Z_]+)}?(.*)$/)
++    if ($str =~ /^(.*)\$\{?([A-Z_]+)}?(.*)$/)
+     {
+ 	my $rest = $3;
+ 	my $untouched = $1;
+@@ -1190,10 +1190,10 @@
+ 	$name    =~ s/\(+$//g;
+ 	$version =~ s/\(+$//g;
+ 
+-	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\${?AC_PACKAGE_NAME}?/);
+-	$varhash{"PACKAGE"} = $name if (not $name =~ /\${?PACKAGE}?/);
+-	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\${?AC_PACKAGE_VERSION}?/);
+-	$varhash{"VERSION"} = $version if (not $name =~ /\${?VERSION}?/);
++	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\$\{?AC_PACKAGE_NAME}?/);
++	$varhash{"PACKAGE"} = $name if (not $name =~ /\$\{?PACKAGE}?/);
++	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\$\{?AC_PACKAGE_VERSION}?/);
++	$varhash{"VERSION"} = $version if (not $name =~ /\$\{?VERSION}?/);
+     }
+ 
+     if ($conf_source =~ /^AC_INIT\(([^,\)]+),([^,\)]+)[,]?([^,\)]+)?/m)
+@@ -1219,11 +1219,11 @@
+ 	$version =~ s/\(+$//g;
+         $bugurl  =~ s/\(+$//g if (defined $bugurl);
+ 
+-	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\${?AC_PACKAGE_NAME}?/);
+-	$varhash{"PACKAGE"} = $name if (not $name =~ /\${?PACKAGE}?/);
+-	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\${?AC_PACKAGE_VERSION}?/);
+-	$varhash{"VERSION"} = $version if (not $name =~ /\${?VERSION}?/);
+-        $varhash{"PACKAGE_BUGREPORT"} = $bugurl if (defined $bugurl and not $bugurl =~ /\${?\w+}?/);
++	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\$\{?AC_PACKAGE_NAME}?/);
++	$varhash{"PACKAGE"} = $name if (not $name =~ /\$\{?PACKAGE}?/);
++	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\$\{?AC_PACKAGE_VERSION}?/);
++	$varhash{"VERSION"} = $version if (not $name =~ /\$\{?VERSION}?/);
++        $varhash{"PACKAGE_BUGREPORT"} = $bugurl if (defined $bugurl and not $bugurl =~ /\$\{?\w+}?/);
+     }
+ 
+     # \s makes this not work, why?

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,16 @@ package:
 source:
   url: http://ftp.gnome.org/pub/gnome/sources/intltool/{{ version.split('.')[:2] | join('.') }}/intltool-{{ version }}.tar.gz
   sha256: 36cd8fe249d0cc20918b6d4583267208bf74c8d541c67a5fe63316846344f9f7
+  patches:
+    # Patch from https://bugs.launchpad.net/intltool/+bug/1490906
+    # Avoids warnings in perl 5.22 which became errors in 5.26
+    - intltool-perl-5.22.patch
+    # Remove the -w from shebangs; conda turns this into
+    # "/usr/bin/env perl -w" which looks for an executable named "perl -w".
+    - remove-w.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
   detect_binary_files_with_prefix: true
 
@@ -24,8 +31,7 @@ requirements:
 
 test:
   commands:
-    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
-    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+    - intltool-update --help
 
 about:
   home: http://www.gtk.org/

--- a/recipe/remove-w.patch
+++ b/recipe/remove-w.patch
@@ -1,0 +1,56 @@
+commit 87727599bb7dbbf387921c608b41615853d81bee
+Author: Dougal J. Sutherland <dougal@gmail.com>
+Date:   Mon Jul 23 17:24:43 2018 +0100
+
+    remove -w from shebangs
+
+diff --git a/intltool-extract.in b/intltool-extract.in
+index 39e7858..c8ca199 100644
+--- a/intltool-extract.in
++++ b/intltool-extract.in
+@@ -1,4 +1,4 @@
+-#!@INTLTOOL_PERL@ -w 
++#!@INTLTOOL_PERL@
+ # -*- Mode: perl; indent-tabs-mode: nil; c-basic-offset: 4  -*-
+ 
+ #
+diff --git a/intltool-merge.in b/intltool-merge.in
+index ee4bdef..f50b4fd 100644
+--- a/intltool-merge.in
++++ b/intltool-merge.in
+@@ -1,4 +1,4 @@
+-#!@INTLTOOL_PERL@ -w
++#!@INTLTOOL_PERL@
+ # -*- Mode: perl; indent-tabs-mode: nil; c-basic-offset: 4  -*-
+ 
+ #
+diff --git a/intltool-prepare.in b/intltool-prepare.in
+index 8c31974..03ea41b 100644
+--- a/intltool-prepare.in
++++ b/intltool-prepare.in
+@@ -1,4 +1,4 @@
+-#!@INTLTOOL_PERL@ -w
++#!@INTLTOOL_PERL@
+ # -*- Mode: perl; indent-tabs-mode: nil; c-basic-offset: 4  -*-
+ 
+ #  Intltool .desktop, .directory Prepare Tool
+diff --git a/intltool-unicodify.in b/intltool-unicodify.in
+index 9821398..f2a007f 100644
+--- a/intltool-unicodify.in
++++ b/intltool-unicodify.in
+@@ -1,4 +1,4 @@
+-#!@INTLTOOL_PERL@ -w
++#!@INTLTOOL_PERL@
+         
+ #
+ #  The i18n Unicode Encoding Utility
+diff --git a/intltool-update.in b/intltool-update.in
+index 74699f3..aeb7095 100644
+--- a/intltool-update.in
++++ b/intltool-update.in
+@@ -1,4 +1,4 @@
+-#!@INTLTOOL_PERL@ -w
++#!@INTLTOOL_PERL@
+ # -*- Mode: perl; indent-tabs-mode: nil; c-basic-offset: 4  -*-
+ 
+ #


### PR DESCRIPTION
- intltool needs a patch to work with perl 5.26.
- Currently shell scripts are installed with shebang line `#!/usr/bin/env perl -w`, which looks for an executable named `perl -w` and so of course doesn't work. Add a patch to just drop the `-w`.
- Add a test that at least the command can run, which would have caught both of the previous two problems. :)